### PR TITLE
Fix inclusion of HunterGate.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@
 
 cmake_minimum_required(VERSION 3.2)
 
-include("${CMAKE_CURRENT_LIST_DIR}/cmake/HunterGate.cmake")
-
 if (NOT HUNTER_URL AND NOT HUNTER_SHA1)
   file(
     DOWNLOAD https://api.github.com/repos/cpp-pm/hunter/releases/latest
@@ -66,7 +64,7 @@ endif()
 
 file(WRITE
   ${CMAKE_BINARY_DIR}/HunterSetup.cmake.in
-  "include(${CMAKE_BINARY_DIR}/HunterGate.cmake)\n"
+  "include(\"${CMAKE_CURRENT_LIST_DIR}/cmake/HunterGate.cmake\")\n"
   "HunterGate(
     URL ${HUNTER_URL}
     SHA1 ${HUNTER_SHA1}


### PR DESCRIPTION
#4  was fixing the inclusion of the file, but that was the wrong place to fix it.

In my original code at the top of the file I had a `file(DOWNLOAD` statement, which I wrongly replaced with `include(cmake/HunterGate`.

Yesterday I didn't have the time to test #4. Today I've tested my gate fork and it works as expect. 

https://github.com/cpp-pm/hunter/issues/56#issuecomment-550152870 had the right suggestion, and I somehow didn't see it.