### PR TITLE
Do not set HUNTER_CONFIGURATION_TYPES to empty build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ configure_file(
   ${CMAKE_BINARY_DIR}/HunterSetup.cmake @ONLY)
 
 # Build only the current CMAKE_BUILD_TYPE
-if (NOT HUNTER_CONFIGURATION_TYPES)
+if (NOT HUNTER_CONFIGURATION_TYPES AND CMAKE_BUILD_TYPE)
   set(HUNTER_CONFIGURATION_TYPES ${CMAKE_BUILD_TYPE} CACHE STRING "Configurations HUNTER will build")
 endif()
 


### PR DESCRIPTION
Fixes https://github.com/cpp-pm/hunter/issues/58

Qt Creator is always setting `CMAKE_BUILD_TYPE` to a value now, and I forgot about the case when `CMAKE_BUILD_TYPE` is empty.