### PR TITLE
Fix HunterToolchain.cmake handling of the installation directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,10 +90,10 @@ include(${CMAKE_BINARY_DIR}/HunterSetup.cmake)
 file(WRITE ${CMAKE_BINARY_DIR}/HunterToolchain.cmake.in
 [=[
 # Add hunter install directory to the find_package variables
-if (EXISTS "${CMAKE_BINARY_DIR}/_3rdParty/Hunter/install-root-dir")
-  file(READ ${CMAKE_BINARY_DIR}/_3rdParty/Hunter/install-root-dir HunterInstall)
-  list(APPEND CMAKE_FIND_ROOT_PATH \"${HunterInstall}\")
-  list(APPEND CMAKE_PREFIX_PATH \"${HunterInstall}\")
+if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/_3rdParty/Hunter/install-root-dir")
+  file(READ "${CMAKE_CURRENT_LIST_DIR}/_3rdParty/Hunter/install-root-dir" HunterInstall)
+  list(APPEND CMAKE_FIND_ROOT_PATH "${HunterInstall}")
+  list(APPEND CMAKE_PREFIX_PATH "${HunterInstall}")
 endif()
 ]=])
 


### PR DESCRIPTION
Using `CMAKE_BINARY_DIR` doesn't make sense if you use the toolchain in a different project than the one that does the `FetchContent` for Hunter packages.