### PR TITLE
Compare HUNTER_GATE_SHA1 after TOLOWER

### DIFF
--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -517,7 +517,9 @@ macro(HunterGate)
         hunter_gate_internal_error("${_sha1_location} not found")
       endif()
       file(READ "${_sha1_location}" _sha1_value)
-      string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
+      string(TOLOWER "${_sha1_value}" _sha1_value_lower)
+      string(TOLOWER "${HUNTER_GATE_SHA1}" _HUNTER_GATE_SHA1_lower)
+      string(COMPARE EQUAL "${_sha1_value_lower}" "${_HUNTER_GATE_SHA1_lower}" _is_equal)
       if(NOT _is_equal)
         hunter_gate_internal_error(
             "Short SHA1 collision:"


### PR DESCRIPTION
Don't depend on sha1sum being created with the same capitalization in HunterGate.
Do it the same way as in `hunter_make_directory` [1], which converts all alphabetical
character to lower-case before comparing the sha1-strings.

[1] https://github.com/cpp-pm/hunter/blob/3b5ce35e418840e080cf6c68accadd70ea31fb58/cmake/modules/hunter_make_directory.cmake#L29

edit: reason for this PR: on Windows the SHA1 sum suddenly didn't compare right anymore because capitalization was different between generated sha1 sum and user provided sha1