### PR TITLE
Silence warnings when building with CMake 3.27

### DIFF
--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -254,6 +254,12 @@ function(hunter_gate_download dir)
       WRITE
       "${cmakelists}"
       "cmake_minimum_required(VERSION 3.5)\n"
+      "if(POLICY CMP0114)\n"
+      "  cmake_policy(SET CMP0114 NEW)\n"
+      "endif()\n"
+      "if(POLICY CMP0135)\n"
+      "  cmake_policy(SET CMP0135 NEW)\n"
+      "endif()\n"
       "project(HunterDownload LANGUAGES NONE)\n"
       "include(ExternalProject)\n"
       "ExternalProject_Add(\n"


### PR DESCRIPTION
* CMake policy CMP0114 (introduced CMake 3.19) warns if ExternalProject is used with Xcode generator and is required to use Xcode 'new build system'
* CMake policy CMP0135 (introduced CMake 3.24) warns if DOWNLOAD_EXTRACT_TIMESTAMP is not specified in ExternalProject.