### PR TITLE
Silence warnings building with CMake v3.31

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2019-2020 Cristian Adam
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.12)
 
 if (NOT HUNTER_URL AND NOT HUNTER_SHA1)
   file(

--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -25,7 +25,7 @@
 # This is a gate file to Hunter package manager.
 # Include this file using `include` command and add package you need, example:
 #
-#     cmake_minimum_required(VERSION 3.5)
+#     cmake_minimum_required(VERSION 3.5...3.12)
 #
 #     include("cmake/HunterGate.cmake")
 #     HunterGate(
@@ -253,7 +253,7 @@ function(hunter_gate_download dir)
   file(
       WRITE
       "${cmakelists}"
-      "cmake_minimum_required(VERSION 3.5)\n"
+      "cmake_minimum_required(VERSION 3.5...3.12)\n"
       "if(POLICY CMP0114)\n"
       "  cmake_policy(SET CMP0114 NEW)\n"
       "endif()\n"


### PR DESCRIPTION
With CMake 3.31 you get warnings if you tell cmake to use a compat version <3.10. Change the version in a backwards compatible way to silence the warnings by upping the compat version to 3.12 but leaving the min version as 3.5

See https://github.com/cpp-pm/hunter/issues/767

On modern cmake this will enable policies CMP0066 through CMP0075 (https://cmake.org/cmake/help/latest/policy/CMP0066.html)